### PR TITLE
Fix push event without payload

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -74,7 +74,7 @@ self.addEventListener('fetch', event => {
 self.addEventListener('push', event => {
   const title = 'Paulo OS';
   const options = {
-    body: event.data.text(),
+    body: event.data ? event.data.text() : 'Nova notificação',
     icon: './icons/icon-192.png',
     vibrate: [100, 50, 100],
     data: {


### PR DESCRIPTION
## Summary
- handle missing `event.data` in push event handler

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688139f6fec0832687431131990e18de